### PR TITLE
Add astyle formatting

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -25,6 +25,25 @@ files = [
 ]
 
 [[package]]
+name = "astyle-py"
+version = "1.0.5"
+description = "Astyle, wrapped in a python package."
+category = "main"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "astyle_py-1.0.5-py2.py3-none-any.whl", hash = "sha256:7649f0b6959878558fafc8d602e4e8e0534bd2319c19959bd3ff2989bcd60d9b"},
+    {file = "astyle_py-1.0.5.tar.gz", hash = "sha256:0a8762c1135bf83947de414437c20dde84cd7bf606368b6721bd0e1d8a9ede54"},
+]
+
+[package.dependencies]
+PyYAML = ">=6.0.1,<6.1.0"
+wasmtime = ">=12.0.0,<12.1.0"
+
+[package.extras]
+dev = ["coverage", "pre-commit", "pytest", "types-PyYAML"]
+
+[[package]]
 name = "black"
 version = "23.10.0"
 description = "The uncompromising code formatter."
@@ -542,7 +561,7 @@ testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "no
 name = "pyyaml"
 version = "6.0.1"
 description = "YAML parser and emitter for Python"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 files = [
@@ -895,7 +914,26 @@ platformdirs = ">=3.9.1,<4"
 docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.2)", "sphinx-argparse (>=0.4)", "sphinxcontrib-towncrier (>=0.2.1a0)", "towncrier (>=23.6)"]
 test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23.1)", "pytest (>=7.4)", "pytest-env (>=0.8.2)", "pytest-freezer (>=0.4.8)", "pytest-mock (>=3.11.1)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)", "setuptools (>=68)", "time-machine (>=2.10)"]
 
+[[package]]
+name = "wasmtime"
+version = "12.0.0"
+description = "A WebAssembly runtime powered by Wasmtime"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "wasmtime-12.0.0-py3-none-any.whl", hash = "sha256:1fee5ac11726cad1f69611779e44ffcb60e912479d1a3c7c77099c3c2f068c36"},
+    {file = "wasmtime-12.0.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:d5e284b37204535a2817f3563102ce8a41451a5f4203db059b051640bda8bcb8"},
+    {file = "wasmtime-12.0.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:2a931214e62aa3d23c61b5f5d2cc47ce10d708f4d8d02e12ea87004c0837e650"},
+    {file = "wasmtime-12.0.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:fa5372d8f3e2bfcaaf7cfffb0d5efc640351889d7aed6d34711f32a85fe9b5ff"},
+    {file = "wasmtime-12.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:c72d1f9b253b97aff19375d6980e3e6380929424fe07b56364413bf54fd80049"},
+    {file = "wasmtime-12.0.0-py3-none-win_amd64.whl", hash = "sha256:7eee12e6bb72123b3beec757d6b48f90b09a1097b1c6dadff7013ffbc46df2fe"},
+]
+
+[package.extras]
+testing = ["coverage", "flake8 (==4.0.1)", "pycparser", "pytest", "pytest-flake8", "pytest-mypy"]
+
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "bb61f59e6fbed4a7f51fb8267f17d300ffa3608c932c8a9b23824aaa9be9a809"
+content-hash = "8d83e271b2403afb3124525c51224ddc49613b8a2dd36f848117c9e2f47cb803"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ tree-sitter = "^0.20.1"
 cleo = "^2.0.1"
 multimethod = "^1.9.1"
 colorama = "^0.4.6"
+astyle-py = "^1.0.5"
 
 [tool.poetry.group.test.dependencies]
 pytest = "^7.3.1"

--- a/src/rt_preproc/cli/patch_cmd.py
+++ b/src/rt_preproc/cli/patch_cmd.py
@@ -12,7 +12,19 @@ class PatchCmd(Command):
         "Patch a file to convert compile-time C preprocessor macros to runtime logic"
     )
     arguments = [argument("file", description="C file to patch", optional=False)]
-    options = [option("output", "o", description="Output file to write to", flag=False)]
+    options = [
+        option("output", "o", description="Output file to write to", flag=False),
+        option(
+            "fmt",
+            "f",
+            description="Run astyle on the output",
+        ),
+        option(
+            "just_output",
+            "j",
+            description="Just output the patched file",
+        ),
+    ]
 
     def runPatch(self, file: str, just_output: bool = False, output_file: str = None):
         if not just_output:
@@ -39,4 +51,8 @@ class PatchCmd(Command):
 
     def handle(self):
         opt = self.option("output")
-        self.runPatch(self.argument("file"), output_file=opt)
+        self.runPatch(
+            self.argument("file"),
+            just_output=self.option("just_output"),
+            output_file=opt,
+        )

--- a/src/rt_preproc/cli/print_cmd.py
+++ b/src/rt_preproc/cli/print_cmd.py
@@ -1,5 +1,5 @@
 from cleo.commands.command import Command
-from cleo.helpers import argument
+from cleo.helpers import argument, option
 from rt_preproc.parser.ast import AstNode
 from rt_preproc.parser.parser import Parser
 from rt_preproc.visitors.print import PrintCtx, PrintVisitor
@@ -8,8 +8,20 @@ from rt_preproc.visitors.print import PrintCtx, PrintVisitor
 class PrintCmd(Command):
     name = "print"
     description = "Print a C file from its AST."
-    arguments = [argument("file", description="C file to print", optional=False)]
-    options = []
+    arguments = [
+        argument("file", description="C file to print", optional=False),
+        argument(
+            "output",
+            description="Output file to write to",
+            optional=True,
+        ),
+    ]
+    options = [
+        option(
+            "fmt",
+            description="Run astyle on the output",
+        )
+    ]
 
     def handle(self):
         file = self.argument("file")
@@ -19,5 +31,7 @@ class PrintCmd(Command):
             ds = Parser()
             tree = ds.parse(bytes)
             root_node = AstNode.reify(tree.root_node)
-            visitor = PrintVisitor()
+            visitor = PrintVisitor(
+                output_file=self.argument("output"), use_astyle=self.option("fmt")
+            )
             root_node.accept(visitor, PrintCtx())

--- a/src/rt_preproc/visitors/print.py
+++ b/src/rt_preproc/visitors/print.py
@@ -2,7 +2,7 @@ from typing import Any
 import rt_preproc.parser.ast as ast
 from multimethod import multimethod
 from rt_preproc.visitors.base import IVisitor, IVisitorCtx
-
+from astyle_py import Astyle
 
 class PrintCtx(IVisitorCtx):
     pass
@@ -11,9 +11,11 @@ class PrintCtx(IVisitorCtx):
 class PrintVisitor(IVisitor):
     """Visitor for printing an AST."""
 
-    def __init__(self, output_file: str = None) -> None:
+    def __init__(self, output_file: str = None, use_astyle: bool = False) -> None:
         super().__init__()
         self.output_file = open(output_file, "w") if output_file else None
+        self.buffer = ""
+        self.use_astyle = use_astyle
 
     @multimethod
     def visit(self, node: ast.AstNode, ctx: PrintCtx) -> Any:
@@ -23,4 +25,20 @@ class PrintVisitor(IVisitor):
         else:  # leaf node
             if self.output_file is not None:
                 self.output_file.write(node.text)
-            print(node.text, end="")
+            if self.use_astyle:
+                self.buffer += node.text
+            else:
+                print(node.text, end="")
+        # if root node, close file and run astyle
+        if isinstance(node, ast.TranslationUnit):
+            if self.use_astyle:
+                formatter = Astyle()
+                formatter.set_options('--style=mozilla --mode=c')
+                self.buffer = formatter.format(self.buffer)
+                if self.output_file is not None:
+                    with open(self.output_file, "w") as f:
+                        f.write(self.buffer)
+                print(self.buffer)
+                self.buffer = ""
+            if self.output_file is not None:
+                self.output_file.close()


### PR DESCRIPTION
This PR provides post-patch formatting.
You can use the `--fmt` flag to get that functionality:
```
poetry run rt_preproc patch ./tests/c/patchtests/macro_sur_var_no_alt/orig.c --fmt 
```